### PR TITLE
Using KinD builtin port mapping

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,6 +43,7 @@ jobs:
           version: v0.11.1
           node_image: kindest/node:${{ matrix.kubernetes }}
           cluster_name: kind
+          config: test/kind/config.yaml
           wait: 120s
 
       - name: Verify KinD cluster
@@ -62,5 +63,4 @@ jobs:
 
       - name: End-to-End Tests
         run: |
-          nohup kubectl port-forward --namespace registry deployment/registry 32222:5000 &
           make test-e2e

--- a/test/e2e/upload.bats
+++ b/test/e2e/upload.bats
@@ -52,7 +52,7 @@ function assert_shp_upload_follow_output() {
 	#
 	# Test Cases
 	#
-	
+
 	run shp build upload ${build_name} "${repo_dir}"
 	assert_success
 	assert_shp_upload_output
@@ -85,8 +85,7 @@ function assert_shp_upload_follow_output() {
 	# local source copy approach.
 	#
 	# Note: This will only work if the registry used for the source bundle image is reachable
-	# from the local shp client. In case of the KinD based registry, this will only work if there
-	# is an entry in the /etc/hosts to resove the cluster local address into localhost.
+	# from the local shp client.
 	#
 	run shp build create ${build_name} \
 		--source-bundle-image="$(get_output_image source-bundle):latest" \

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,0 +1,10 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 32222
+        hostPort: 32222
+        listenAddress: "0.0.0.0"
+        protocol: TCP


### PR DESCRIPTION
# Changes

Using KinD `extraPortMappings` config to expose container registry port.

(Refers to https://github.com/shipwright-io/cli/pull/106)